### PR TITLE
Normalize letter-suffix versions for ordering

### DIFF
--- a/pkg/net/default.go
+++ b/pkg/net/default.go
@@ -206,12 +206,14 @@ func CheckUpdates(b models.Binaries, a ...string) (models.Binaries, error) {
 		checkV.CurrentVersion = "0.0.0"
 	}
 
-	currentVersion, err := version.NewVersion(checkV.CurrentVersion)
+	// Normalize letter-suffix releases (e.g. tmux 3.6a -> 3.6.1) so semver
+	// comparison orders them as post-release patches, not pre-releases.
+	currentVersion, err := version.NewVersion(utils.NormalizeLetterSuffix(checkV.CurrentVersion))
 	if err != nil {
 		return models.Binaries{}, fmt.Errorf("error parsing the current version for: %s - %w ", b.Name, err)
 	}
 
-	newVersion, err := version.NewVersion(checkV.NewVersion)
+	newVersion, err := version.NewVersion(utils.NormalizeLetterSuffix(checkV.NewVersion))
 	if err != nil {
 		return models.Binaries{}, fmt.Errorf("error parsing the new version for: %s - %w ", b.Name, err)
 	}
@@ -480,12 +482,12 @@ func verifyNewBin(b models.Binaries) error {
 			return fmt.Errorf("failed to compile regex for %s: %w", file.FileName, err)
 		}
 
-		installedVersion, err := version.NewVersion(strings.TrimSpace(match))
+		installedVersion, err := version.NewVersion(utils.NormalizeLetterSuffix(strings.TrimSpace(match)))
 		if err != nil {
 			return fmt.Errorf("failed to parse installed version for %s: %w", file.FileName, err)
 		}
 
-		newVersion, err := version.NewVersion(strings.TrimSpace(b.NewVersion))
+		newVersion, err := version.NewVersion(utils.NormalizeLetterSuffix(strings.TrimSpace(b.NewVersion)))
 		if err != nil {
 			return fmt.Errorf("failed to parse new version for %s: %w", file.FileName, err)
 		}

--- a/pkg/net/default_test.go
+++ b/pkg/net/default_test.go
@@ -973,6 +973,69 @@ func TestCheckUpdates(t *testing.T) {
 		assert.Equal(t, "Not Found", got.CurrentVersion)
 	})
 
+	t.Run("letter_suffix_release_is_post_release", func(t *testing.T) {
+		// Regression: tmux 3.6a is a post-release patch of 3.6, so an installed
+		// 3.6 must be detected as out-of-date relative to a 3.6a release.
+		// Without NormalizeLetterSuffix, hashicorp/go-version would treat 3.6a
+		// as a pre-release ("3.6.0-a") and rank it below plain 3.6.
+		bindir := t.TempDir()
+		writeShellScript(t, bindir, "tmux", `echo "tmux 3.6"`)
+		t.Setenv("PATH", bindir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+		assetName := currentOSArchAssetName("tar.gz")
+		withGitHubServer(t, "3.6a", []*github.ReleaseAsset{{
+			Name:               github.Ptr(assetName),
+			BrowserDownloadURL: github.Ptr("https://example.test/" + assetName),
+			ContentType:        github.Ptr("application/gzip"),
+		}})
+
+		b := models.Binaries{
+			URL: "https://github.com/tmux/tmux",
+			Files: []models.File{{
+				FileName:     "tmux",
+				CheckVersion: true,
+				VersionCommand: models.VersionCommand{
+					Args:         "-V",
+					RegexVersion: `\d+(?:\.\d+)+[a-z]?`,
+				},
+			}},
+		}
+		got, err := CheckUpdates(b)
+		require.NoError(t, err)
+		assert.True(t, got.UpdatesAvailable, "3.6a should be detected as newer than 3.6")
+		assert.Equal(t, "3.6", got.CurrentVersion)
+		assert.Equal(t, "3.6a", got.NewVersion)
+	})
+
+	t.Run("letter_suffix_already_installed", func(t *testing.T) {
+		// Same letter on both sides should report no update.
+		bindir := t.TempDir()
+		writeShellScript(t, bindir, "tmux", `echo "tmux 3.6a"`)
+		t.Setenv("PATH", bindir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+		assetName := currentOSArchAssetName("tar.gz")
+		withGitHubServer(t, "3.6a", []*github.ReleaseAsset{{
+			Name:               github.Ptr(assetName),
+			BrowserDownloadURL: github.Ptr("https://example.test/" + assetName),
+			ContentType:        github.Ptr("application/gzip"),
+		}})
+
+		b := models.Binaries{
+			URL: "https://github.com/tmux/tmux",
+			Files: []models.File{{
+				FileName:     "tmux",
+				CheckVersion: true,
+				VersionCommand: models.VersionCommand{
+					Args:         "-V",
+					RegexVersion: `\d+(?:\.\d+)+[a-z]?`,
+				},
+			}},
+		}
+		got, err := CheckUpdates(b)
+		require.NoError(t, err)
+		assert.False(t, got.UpdatesAvailable)
+	})
+
 	t.Run("binary_not_installed_no_matching_asset_returns_empty", func(t *testing.T) {
 		t.Setenv("PATH", t.TempDir())
 

--- a/pkg/utils/default.go
+++ b/pkg/utils/default.go
@@ -172,6 +172,34 @@ func ExtractVersion(version, regex string) (string, error) {
 	return "", nil
 }
 
+// letterSuffixRe matches a numeric version with a single trailing lowercase
+// letter (e.g. "3.6a", "v1.1.1k"). Group 1 is the numeric part (with optional
+// "v"), group 2 is the suffix letter.
+var letterSuffixRe = regexp.MustCompile(`^(v?\d+(?:\.\d+)+)([a-z])$`)
+
+// NormalizeLetterSuffix converts a version string with a single trailing
+// lowercase letter into a numeric form with the letter position appended as
+// an extra patch segment, e.g. "3.6a" -> "3.6.1", "1.1.1k" -> "1.1.1.11".
+//
+// This makes letter-suffix patch releases (used by tmux, OpenSSL, and other
+// projects) order correctly under standard semver comparison: 3.6 < 3.6a <
+// 3.6b < 3.7. Without this conversion, hashicorp/go-version interprets the
+// letter as a semver pre-release and orders 3.6a < 3.6, which is the
+// opposite of these projects' conventions.
+//
+// Inputs without a trailing letter, with multiple trailing letters, or with
+// a hyphen-separated semver pre-release (e.g. "1.0.0-beta1") are returned
+// unchanged.
+func NormalizeLetterSuffix(v string) string {
+	trimmed := strings.TrimSpace(v)
+	m := letterSuffixRe.FindStringSubmatch(trimmed)
+	if m == nil {
+		return v
+	}
+	pos := int(m[2][0]-'a') + 1
+	return fmt.Sprintf("%s.%d", m[1], pos)
+}
+
 // NormalizeArch normalizes architecture names to Go's runtime.GOARCH values
 func NormalizeArch(arch string) string {
 	switch strings.ToLower(arch) {

--- a/pkg/utils/default_test.go
+++ b/pkg/utils/default_test.go
@@ -244,6 +244,39 @@ func FuzzExtractVersion(f *testing.F) {
 	})
 }
 
+func TestNormalizeLetterSuffix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"3.6", "3.6"},
+		{"3.6a", "3.6.1"},
+		{"3.6b", "3.6.2"},
+		{"3.6z", "3.6.26"},
+		{"v3.6a", "v3.6.1"},
+		{"3.6.4", "3.6.4"},
+		{"3.6.4a", "3.6.4.1"},
+		{"1.1.1k", "1.1.1.11"},
+		{"  3.6a  ", "3.6.1"},
+		// Leave alone: hyphen-separated semver pre-release.
+		{"1.0.0-beta1", "1.0.0-beta1"},
+		// Leave alone: multi-letter suffixes are ambiguous.
+		{"3.6aa", "3.6aa"},
+		// Leave alone: not a numeric version at all.
+		{"abc", "abc"},
+		{"", ""},
+		// Leave alone: single number isn't <X.Y> shape.
+		{"3a", "3a"},
+		// Leave alone: uppercase suffix (uncommon, easy to extend later).
+		{"3.6A", "3.6A"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeLetterSuffix(tt.input))
+		})
+	}
+}
+
 func TestNormalizeArch(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
tmux/OpenSSL-style "3.6a" releases are post-release patches, but hashicorp/go-version parses them as pre-releases ("3.6.0-a") and orders them below plain "3.6". Convert the trailing letter into an extra patch segment ("3.6a" -> "3.6.1") before comparing in CheckUpdates and verifyNewBin so update detection works for these projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version comparison logic to correctly handle version strings with letter suffixes (e.g., "3.6a"), enabling accurate update availability detection.
  * Enhanced version matching verification to normalize version formats consistently across all comparison operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->